### PR TITLE
use type aliases for shorthand constraints

### DIFF
--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -32,7 +32,7 @@ __all__ = (
     'Predicate',
     'LowerCase',
     'UpperCase',
-    'OnlyDigits',
+    'IsDigits',
     '__version__',
 )
 
@@ -150,5 +150,5 @@ StrType = TypeVar("StrType", bound=str)
 
 LowerCase = Annotated[StrType, Predicate(str.islower)]
 UpperCase = Annotated[StrType, Predicate(str.isupper)]
-OnlyDigits = Annotated[StrType, Predicate(str.isdigit)]
-OnlyAscii = Annotated[StrType, Predicate(str.isascii)]
+IsDigits = Annotated[StrType, Predicate(str.isdigit)]
+IsAscii = Annotated[StrType, Predicate(str.isascii)]

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -30,9 +30,9 @@ __all__ = (
     'Regex',
     'Timezone',
     'Predicate',
-    'IsLower',
-    'IsUpper',
-    'IsDigit',
+    'LowerCase',
+    'UpperCase',
+    'OnlyDigits',
     '__version__',
 )
 
@@ -146,7 +146,9 @@ class Predicate(BaseMetadata):
     func: Callable[[Any], bool]
 
 
-IsLower = Predicate(str.islower)
-IsUpper = Predicate(str.isupper)
-IsDigit = Predicate(str.isdigit)
-IsAscii = Predicate(str.isascii)
+StrType = TypeVar("StrType", bound=str)
+
+LowerCase = Annotated[StrType, Predicate(str.islower)]
+UpperCase = Annotated[StrType, Predicate(str.isupper)]
+OnlyDigits = Annotated[StrType, Predicate(str.isdigit)]
+OnlyAscii = Annotated[StrType, Predicate(str.isascii)]

--- a/annotated_types/test_cases.py
+++ b/annotated_types/test_cases.py
@@ -132,9 +132,9 @@ def cases() -> Iterable[Case]:
 
     # predicate types
 
-    yield Case(Annotated[str, at.IsLower], ['abc', 'foobar'], ['', 'A', 'Boom'])
-    yield Case(Annotated[str, at.IsUpper], ['ABC', 'DEFO'], ['', 'a', 'abc', 'AbC'])
-    yield Case(Annotated[str, at.IsDigit], ['123'], ['', 'ab', 'a1b2'])
-    yield Case(Annotated[str, at.IsAscii], ['123', 'foo bar'], ['£100', '😊', 'whatever 👀'])
+    yield Case(at.LowerCase[str], ['abc', 'foobar'], ['', 'A', 'Boom'])
+    yield Case(at.UpperCase[str], ['ABC', 'DEFO'], ['', 'a', 'abc', 'AbC'])
+    yield Case(at.OnlyDigits[str], ['123'], ['', 'ab', 'a1b2'])
+    yield Case(at.OnlyAscii[str], ['123', 'foo bar'], ['£100', '😊', 'whatever 👀'])
 
     yield Case(Annotated[int, at.Predicate(lambda x: x % 2 == 0)], [0, 2, 4], [1, 3, 5])

--- a/annotated_types/test_cases.py
+++ b/annotated_types/test_cases.py
@@ -134,7 +134,7 @@ def cases() -> Iterable[Case]:
 
     yield Case(at.LowerCase[str], ['abc', 'foobar'], ['', 'A', 'Boom'])
     yield Case(at.UpperCase[str], ['ABC', 'DEFO'], ['', 'a', 'abc', 'AbC'])
-    yield Case(at.OnlyDigits[str], ['123'], ['', 'ab', 'a1b2'])
-    yield Case(at.OnlyAscii[str], ['123', 'foo bar'], ['£100', '😊', 'whatever 👀'])
+    yield Case(at.IsDigits[str], ['123'], ['', 'ab', 'a1b2'])
+    yield Case(at.IsAscii[str], ['123', 'foo bar'], ['£100', '😊', 'whatever 👀'])
 
     yield Case(Annotated[int, at.Predicate(lambda x: x % 2 == 0)], [0, 2, 4], [1, 3, 5])


### PR DESCRIPTION
https://github.com/annotated-types/annotated-types/pull/5#issuecomment-1118094109

I think these names make more sense when they're wrapping the type, but I'm happy to keep the old ones