### PR TITLE
add GroupedMetadata as a base class for Interval

### DIFF
--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -158,7 +158,7 @@ class GroupedMetadata(BaseMetadata):
     Parsers should recognize this and unpack it so that it can be used
     both with and without unpacking:
 
-    - `Annotated[int, Field(...)]`
+    - `Annotated[int, Field(...)]` (parser must unpack Field)
     - `Annotated[int, *Field(...)]` (PEP-646)
     """  # noqa: trailing-whitespace
 

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -153,6 +153,8 @@ class GroupedMetadata(BaseMetadata):
     >>>         if self.description is not None:
     >>>             yield Description(self.gt)
 
+    Also see the implementation of `Interval` below for an example.
+
     Parsers should recognize this and unpack it so that it can be used
     both with and without unpacking:
 

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -88,6 +88,8 @@ class BaseMetadata:
     can do `isinstance(..., BaseMetadata)` while traversing field annotations.
     """
 
+    __slots__ = ()
+
 
 @dataclass(frozen=True, **SLOTS)
 class Gt(BaseMetadata):
@@ -133,7 +135,7 @@ class Le(BaseMetadata):
     le: SupportsLe
 
 
-class GroupedMetadata:
+class GroupedMetadata(BaseMetadata):
     """A grouping of multiple BaseMetadata objects.
 
     Concrete implementations should override this to add their own
@@ -144,7 +146,7 @@ class GroupedMetadata:
     >>> class Field(GroupedMetadata):
     >>>     gt: float | None = None
     >>>     description: str | None = None
-    ...    
+    ...
     >>>     def __iter__(self) -> Iterable[BaseMetadata]:
     >>>         if self.gt is not None:
     >>>             yield Gt(self.gt)
@@ -156,7 +158,10 @@ class GroupedMetadata:
 
     - `Annotated[int, Field(...)]`
     - `Annotated[int, *Field(...)]` (PEP-646)
-    """
+    """  # noqa: trailing-whitespace
+
+    __slots__ = ()
+
     def __iter__(self) -> Iterable[BaseMetadata]:
         return ()
 

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -164,7 +164,7 @@ class GroupedMetadata(BaseMetadata):
 
     __slots__ = ()
 
-    def __iter__(self) -> Iterable[BaseMetadata]:
+    def __iter__(self) -> Iterable[BaseMetadata]:  # pragma: no cover
         return ()
 
 

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -161,7 +161,6 @@ class GroupedMetadata:
         return ()
 
 
-
 @dataclass(frozen=True, **KW_ONLY, **SLOTS)
 class Interval(GroupedMetadata):
     """Interval can express inclusive or exclusive bounds with a single object.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -98,11 +98,10 @@ def get_constraints(tp: type) -> Iterator[Constraint]:
     next(args)
     for arg in args:
         if isinstance(arg, (annotated_types.BaseMetadata, re.Pattern, slice)):
-            if isinstance(arg, annotated_types.Interval):
-                for case in arg:
-                    yield case
-            else:
-                yield arg
+            yield arg
+        elif isinstance(arg, annotated_types.GroupedMetadata):
+            for case in arg:
+                yield case
 
 
 def is_valid(tp: type, value: Any) -> bool:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -100,8 +100,7 @@ def get_constraints(tp: type) -> Iterator[Constraint]:
         if isinstance(arg, (annotated_types.BaseMetadata, re.Pattern, slice)):
             yield arg
         elif isinstance(arg, annotated_types.GroupedMetadata):
-            for case in arg:
-                yield case
+            yield from arg
 
 
 def is_valid(tp: type, value: Any) -> bool:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Iterator, Type, Union
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
 import annotated_types
 from annotated_types.test_cases import Case, cases
 
-Constraint = Union[annotated_types.BaseMetadata, slice]
+Constraint = Union[annotated_types.BaseMetadata, slice, "re.Pattern[bytes]", "re.Pattern[str]"]
 
 
 def check_gt(constraint: Constraint, val: Any) -> bool:
@@ -96,12 +97,10 @@ def get_constraints(tp: type) -> Iterator[Constraint]:
     args = iter(get_args(tp))
     next(args)
     for arg in args:
-        if isinstance(arg, (annotated_types.BaseMetadata, slice)):
-            if isinstance(arg, annotated_types.Interval):
-                for case in arg:
-                    yield case
-            else:
-                yield arg
+        if isinstance(arg, (annotated_types.BaseMetadata, re.Pattern, slice)):
+            yield arg
+        elif isinstance(arg, annotated_types.GroupedMetadata):
+            yield from arg
 
 
 def is_valid(tp: type, value: Any) -> bool:


### PR DESCRIPTION
The main idea here is to generalize the pattern in `Interval` so that Pydantic and similar can define their `Field` as inheriting from `GroupedMetadata`, thus anything that can parse `annotated-types` will know how to unpack it (if it is not already unpacked by the PEP-646) even if it is a custom subclass in a library like `Pydantic`.

Without this, some generic `annotated-types` parser would not know how to handle `Pydantic`'s `Field` type without specific knowledge of Pydantic.