### PR TITLE
Remove regex from tests (again)

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,3 @@
-import re
 import sys
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Iterator, Type, Union
@@ -16,7 +15,7 @@ if TYPE_CHECKING:
 import annotated_types
 from annotated_types.test_cases import Case, cases
 
-Constraint = Union[annotated_types.BaseMetadata, slice, "re.Pattern[bytes]", "re.Pattern[str]"]
+Constraint = Union[annotated_types.BaseMetadata, slice]
 
 
 def check_gt(constraint: Constraint, val: Any) -> bool:
@@ -97,7 +96,7 @@ def get_constraints(tp: type) -> Iterator[Constraint]:
     args = iter(get_args(tp))
     next(args)
     for arg in args:
-        if isinstance(arg, (annotated_types.BaseMetadata, re.Pattern, slice)):
+        if isinstance(arg, (annotated_types.BaseMetadata, slice)):
             yield arg
         elif isinstance(arg, annotated_types.GroupedMetadata):
             yield from arg


### PR DESCRIPTION
I mucked up a merge conflict resolution in #12 which reverted #13, so this is just cherry picking the commit from #13 to remove regex again.