### PR TITLE
Use `any()` instead of for loop & Invert `any/all` to simplify comparisons

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -102,10 +102,7 @@ def get_constraints(tp: type) -> Iterator[Constraint]:
 
 
 def is_valid(tp: type, value: Any) -> bool:
-    for constraint in get_constraints(tp):
-        if not VALIDATORS[type(constraint)](constraint, value):
-            return False
-    return True
+    return all(VALIDATORS[type(constraint)](constraint, value) for constraint in get_constraints(tp))
 
 
 def extract_valid_testcases(case: Case) -> "Iterable[ParameterSet]":


### PR DESCRIPTION
Using Python's `any()` and `all()` built-in functions is a more concise way of doing this than using a for a loop.

`any()` will return True when at least one of the elements evaluates to True, `all()` will return True only when all the elements evaluate to True.