### PR TITLE
fix license display, readme tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,8 @@ class MyClass:
     factors: list[Annotated[int, Predicate(is_prime)]]  # Valid: 2, 3, 5, 7, 11, ...
                                                         # Invalid: 4, 8, -2, 5.0, "prime", ...
 
-    my_list: Annotated[list[int], 0:10]                 # Valid: [], [10, 20, 30, 40, 50]
+    my_list: Annotated[list[int], Len(0, 10)]           # Valid: [], [10, 20, 30, 40, 50]
                                                         # Invalid: (1, 2), ["abc"], [0] * 20
-    your_set: Annotated[set[int], Len(0, 10)]           # Valid: {1, 2, 3}, ...
-                                                        # Invalid: "Well, you get the idea!"
 ```
 
 ## Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 readme = "README.md"
 repository = "https://github.com/annotated-types/annotated-types"
-license = {file = "LICENSE"}
+license-files = { paths = ['LICENSE'] }
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
See https://github.com/pydantic/pydantic/pull/4520 for discussion of license expression, current value is leading to:

![image](https://user-images.githubusercontent.com/4039449/196406925-14a80562-fcdf-4ae3-a287-293bb2f54cb3.png)

See https://pypi.org/project/annotated-types/0.4.0/

Also remove remaining erroneous slice usage for length.