### PR TITLE
Add Deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,27 @@ and then propogate or discard the resulting
 `TypeError: descriptor 'isdigit' for 'str' objects doesn't apply to a 'int' object`
 exception.  We encourage libraries to document the behaviour they choose.
 
+### Deprecated
+
+This can be used to mark parameters and fields as deprecated.
+
+```python
+from dataclasses import dataclass
+
+from annotated_types import Deprecated
+
+
+def f(x: int, y: int, z: Deprecated[int]) -> int:
+    ...
+
+
+class Foo:
+    x: int
+    y: Deprecated[int]
+```
+
+Implementers can use this to emit warnings or mark a field as deprecated in schema.
+
 ### Integrating downstream types with `GroupedMetadata`
 
 Implementers may choose to provide a convenience wrapper that groups multiple pieces of metadata.

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -307,3 +307,13 @@ LowerCase = Annotated[StrType, Predicate(str.islower)]
 UpperCase = Annotated[StrType, Predicate(str.isupper)]
 IsDigits = Annotated[StrType, Predicate(str.isdigit)]
 IsAscii = Annotated[StrType, Predicate(str.isascii)]
+
+
+@dataclass(**SLOTS)
+class Deprecate(BaseMetadata):
+    """Marks a parameter or field as deprecated"""
+
+    message: str
+
+
+Deprecated = Annotated[T, Deprecate(message='')]


### PR DESCRIPTION
cc @tiangolo @JelleZijlstra @samuelcolvin 

Open question: can we design this in a way to be compatible with the version of `@typing.deprecated` that returns something useful at runtime? It would be nice if it returns a class that we can insert into the bases of this one so that anyone doing something like `for annotation in annotations: ... isinstance(annotation, typing.Deprecated` is okay.