### PR TITLE
✨ Add support for `doc()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ and then propogate or discard the resulting
 `TypeError: descriptor 'isdigit' for 'str' objects doesn't apply to a 'int' object`
 exception.  We encourage libraries to document the behaviour they choose.
 
+### Doc
+
+`doc()` can be used to add documentation information in `Annotated`, for function and method parameters, variables, class attributes, return types, and any place where `Annotated` can be used.
+
+It expects a value that can be statically analyzed, as the main use case is for static analysis, editors, documentation generators, and similar tools.
+
+It returns a `DocInfo` class with a single attribute `documentation` containing the value passed to `doc()`.
+
+This is the early adopter's alternative form of the [`typing-doc` proposal](https://github.com/tiangolo/fastapi/blob/typing-doc/typing_doc.md).
+
 ### Integrating downstream types with `GroupedMetadata`
 
 Implementers may choose to provide a convenience wrapper that groups multiple pieces of metadata.

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -48,6 +48,8 @@ __all__ = (
     'IsNotNan',
     'IsInfinite',
     'IsNotInfinite',
+    'doc',
+    'DocInfo',
     '__version__',
 )
 
@@ -366,3 +368,29 @@ IsInfinite = Annotated[_NumericType, Predicate(math.isinf)]
 """Return True if x is a positive or negative infinity, and False otherwise."""
 IsNotInfinite = Annotated[_NumericType, Predicate(Not(math.isinf))]
 """Return True if x is neither a positive or negative infinity, and False otherwise."""
+
+try:
+    from typing_extensions import DocInfo, doc  # type: ignore [attr-defined]
+except ImportError:
+
+    @dataclass(frozen=True, **SLOTS)
+    class DocInfo:  # type: ignore [no-redef]
+        """ "
+        The return value of doc(), mainly to be used by tools that want to extract the
+        Annotated documentation at runtime.
+        """
+
+        documentation: str
+        """The documentation string passed to doc()."""
+
+    def doc(
+        documentation: str,
+    ) -> DocInfo:
+        """
+        Add documentation to a type annotation inside of Annotated.
+
+        For example:
+
+        >>> def hi(name: Annotated[int, doc("The name of the user")]) -> None: ...
+        """
+        return DocInfo(documentation)

--- a/annotated_types/test_cases.py
+++ b/annotated_types/test_cases.py
@@ -136,6 +136,9 @@ def cases() -> Iterable[Case]:
     # check stacked predicates
     yield Case(at.IsInfinite[Annotated[float, at.Predicate(lambda x: x > 0)]], [math.inf], [-math.inf, 1.23, math.nan])
 
+    # doc
+    yield Case(Annotated[int, at.doc("A number")], [1, 2], [])
+
     # custom GroupedMetadata
     class MyCustomGroupedMetadata(at.GroupedMetadata):
         def __iter__(self) -> Iterator[at.Predicate]:


### PR DESCRIPTION
✨ Add support for `doc()`, for the doc proposal to add annotations in `Annotated` for parameters and others: https://github.com/tiangolo/fastapi/blob/typing-doc/typing_doc.md

If this ends up here, I would update the doc to make this the alternate form (instead of the local stub code).

This would ideally end up in `typing_extensions`, a PEP, and ultimately `typing`. But having it here would make it much easier for early adopters like FastAPI, Typer, SQLModel, Asyncer... possibly Pydantic, Strawberry, and maybe others.