### PR TITLE
Allow `tzinfo` objects for `Timezone`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ See [issue #23](https://github.com/annotated-types/annotated-types/issues/23) fo
 are allowed. `Annotated[datetime, Timezone(None)]` must be a naive datetime.
 `Timezone[...]` ([literal ellipsis](https://docs.python.org/3/library/constants.html#Ellipsis))
 expresses that any timezone-aware datetime is allowed. You may also pass a specific
-timezone string or `timezone` object such as `Timezone(timezone.utc)` or
-`Timezone("Africa/Abidjan")` to express that you only allow a specific timezone,
-though we note that this is often a symptom of fragile design.
+timezone string or [`tzinfo`](https://docs.python.org/3/library/datetime.html#tzinfo-objects)
+object such as `Timezone(timezone.utc)` or `Timezone("Africa/Abidjan")` to express that you only
+allow a specific timezone, though we note that this is often a symptom of fragile design.
 
 ### Predicate
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ timezone string or [`tzinfo`](https://docs.python.org/3/library/datetime.html#tz
 object such as `Timezone(timezone.utc)` or `Timezone("Africa/Abidjan")` to express that you only
 allow a specific timezone, though we note that this is often a symptom of fragile design.
 
+#### Changed in v0.x.x
+
+* `Timezone` accepts [`tzinfo`](https://docs.python.org/3/library/datetime.html#tzinfo-objects) objects instead of
+  `timezone`, extending compatibility to [`zoneinfo`](https://docs.python.org/3/library/zoneinfo.html) and third party libraries.
+
 ### Predicate
 
 `Predicate(func: Callable)` expresses that `func(value)` is truthy for valid values.

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -1,7 +1,7 @@
 import math
 import sys
 from dataclasses import dataclass
-from datetime import timezone
+from datetime import tzinfo
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, SupportsFloat, SupportsIndex, TypeVar, Union
 
 if sys.version_info < (3, 8):
@@ -286,13 +286,13 @@ class Timezone(BaseMetadata):
     ``Timezone[...]`` (the ellipsis literal) expresses that the datetime must be
     tz-aware but any timezone is allowed.
 
-    You may also pass a specific timezone string or timezone object such as
+    You may also pass a specific timezone string or tzinfo object such as
     ``Timezone(timezone.utc)`` or ``Timezone("Africa/Abidjan")`` to express that
     you only allow a specific timezone, though we note that this is often
     a symptom of poor design.
     """
 
-    tz: Union[str, timezone, EllipsisType, None]
+    tz: Union[str, tzinfo, EllipsisType, None]
 
 
 @dataclass(frozen=True, **SLOTS)


### PR DESCRIPTION
This way [`zoneinfo`](https://docs.python.org/3/library/zoneinfo.html) or third party libraries can be used as well.
Related: https://github.com/HypothesisWorks/hypothesis/pull/3780