### PR TITLE
add URLs to `pyproject.toml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12-dev']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     runs-on: ubuntu-latest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,14 @@ classifiers = [
     "Typing :: Typed",
 ]
 
+requires-python = ">=3.8"
+dependencies = ["typing-extensions>=4.0.0; python_version<'3.9'"]
+dynamic = ["version"]
+
 [project.urls]
 Homepage = "https://github.com/annotated-types/annotated-types"
 Source = "https://github.com/annotated-types/annotated-types"
 Changelog = "https://github.com/annotated-types/annotated-types/releases"
-
-requires-python = ">=3.8"
-dependencies = ["typing-extensions>=4.0.0; python_version<'3.9'"]
-dynamic = ["version"]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 name = "annotated-types"
 description = "Reusable constraint types to use with typing.Annotated"
 authors = [
-    {name = "Samuel Colvin", email = "s@muelcolvin.com"},
     {name = "Adrian Garcia Badaracco", email = "1755071+adriangb@users.noreply.github.com"},
+    {name = "Samuel Colvin", email = "s@muelcolvin.com"},
     {name = "Zac Hatfield-Dodds", email = "zac@zhd.dev"},
 ]
 readme = "README.md"
@@ -27,6 +27,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
+
+[project.urls]
+Homepage = "https://github.com/annotated-types/annotated-types"
+Source = "https://github.com/annotated-types/annotated-types"
+Changelog = "https://github.com/annotated-types/annotated-types/releases"
 
 requires-python = ">=3.8"
 dependencies = ["typing-extensions>=4.0.0; python_version<'3.9'"]


### PR DESCRIPTION
I looked at the pypi page (which came top of google for me when searching "python annotated-types") and saw we have no link to the repo.

I also moved Adrian up to first author so he's listed as author in pypi, because I feel his is kind of the primary author.