### PR TITLE
Correct misstatement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,17 +132,20 @@ allow a specific timezone, though we note that this is often a symptom of fragil
 Users should prefer the statically inspectable metadata above, but if you need
 the full power and flexibility of arbitrary runtime predicates... here it is.
 
-We provide a few predefined predicates for common string constraints:
+For some common constraints, we provide generic types:
 
-* `IsLower = Predicate(str.islower)`
-* `IsUpper = Predicate(str.isupper)`
-* `IsDigit = Predicate(str.isdigit)`
-* `IsFinite = Predicate(math.isfinite)`
-* `IsNotFinite = Predicate(Not(math.isfinite))`
-* `IsNan = Predicate(math.isnan)`
-* `IsNotNan = Predicate(Not(math.isnan))`
-* `IsInfinite = Predicate(math.isinf)`
-* `IsNotInfinite = Predicate(Not(math.isinf))`
+* `IsLower       = Annotated[T, Predicate(str.islower)]`
+* `IsUpper       = Annotated[T, Predicate(str.isupper)]`
+* `IsDigit       = Annotated[T, Predicate(str.isdigit)]`
+* `IsFinite      = Annotated[T, Predicate(math.isfinite)]`
+* `IsNotFinite   = Annotated[T, Predicate(Not(math.isfinite))]`
+* `IsNan         = Annotated[T, Predicate(math.isnan)]`
+* `IsNotNan      = Annotated[T, Predicate(Not(math.isnan))]`
+* `IsInfinite    = Annotated[T, Predicate(math.isinf)]`
+* `IsNotInfinite = Annotated[T, Predicate(Not(math.isinf))]`
+
+so that you can write e.g. `x: IsFinite[float] = 2.0` instead of the longer
+(but exactly equivalent) `x: Annotated[float, Predicate(math.isfinite)] = 2.0`.
 
 Some libraries might have special logic to handle known or understandable predicates,
 for example by checking for `str.isdigit` and using its presence to both call custom

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ To enable basic negation of commonly used predicates like `math.isnan` without i
 We do not specify what behaviour should be expected for predicates that raise
 an exception.  For example `Annotated[int, Predicate(str.isdigit)]` might silently
 skip invalid constraints, or statically raise an error; or it might try calling it
-and then propogate or discard the resulting
+and then propagate or discard the resulting
 `TypeError: descriptor 'isdigit' for 'str' objects doesn't apply to a 'int' object`
 exception.  We encourage libraries to document the behaviour they choose.
 

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -1,5 +1,6 @@
 import math
 import sys
+import types
 from dataclasses import dataclass
 from datetime import tzinfo
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, SupportsFloat, SupportsIndex, TypeVar, Union
@@ -318,6 +319,17 @@ class Predicate(BaseMetadata):
     """
 
     func: Callable[[Any], bool]
+
+    def __repr__(self) -> str:
+        if getattr(self.func, "__name__", "<lambda>") == "<lambda>":
+            return f"{self.__class__.__name__}({self.func!r})"
+        if isinstance(self.func, (types.MethodType, types.BuiltinMethodType)) and (
+            namespace := getattr(self.func.__self__, "__name__", None)
+        ):
+            return f"{self.__class__.__name__}({namespace}.{self.func.__name__})"
+        if isinstance(self.func, type(str.isascii)):  # method descriptor
+            return f"{self.__class__.__name__}({self.func.__qualname__})"
+        return f"{self.__class__.__name__}({self.func.__name__})"
 
 
 @dataclass

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -314,7 +314,7 @@ class Predicate(BaseMetadata):
     We do not specify what behaviour should be expected for predicates that raise
     an exception.  For example `Annotated[int, Predicate(str.isdigit)]` might silently
     skip invalid constraints, or statically raise an error; or it might try calling it
-    and then propogate or discard the resulting exception.
+    and then propagate or discard the resulting exception.
     """
 
     func: Callable[[Any], bool]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import math
 import sys
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Iterator, Type, Union
@@ -135,3 +136,21 @@ def test_valid_cases(annotation: type, example: Any) -> None:
 )
 def test_invalid_cases(annotation: type, example: Any) -> None:
     assert is_valid(annotation, example) is False
+
+
+def a_predicate_fn(x: object) -> bool:
+    return not x
+
+
+@pytest.mark.parametrize(
+    "pred, repr_",
+    [
+        (annotated_types.Predicate(func=a_predicate_fn), "Predicate(a_predicate_fn)"),
+        (annotated_types.Predicate(func=str.isascii), "Predicate(str.isascii)"),
+        (annotated_types.Predicate(func=math.isfinite), "Predicate(math.isfinite)"),
+        (annotated_types.Predicate(func=bool), "Predicate(bool)"),
+        (annotated_types.Predicate(func := lambda _: True), f"Predicate({func!r})"),
+    ],
+)
+def test_predicate_repr(pred: annotated_types.Predicate, repr_: str) -> None:
+    assert repr(pred) == repr_


### PR DESCRIPTION
Fixes #61, and a typo I spotted.

Following https://github.com/HypothesisWorks/hypothesis/issues/3891#issuecomment-1957683938, I've also defined `Predicate.__repr__`, so that we see e.g. `Predicate(str.isascii)` instead of `Predicate(func=<method 'isascii' of 'str' objects>)` in error messages.