### PR TITLE
Fix IsDigit -> IsDigits

### DIFF
--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -305,7 +305,7 @@ class Predicate(BaseMetadata):
 
     We provide a few predefined predicates for common string constraints:
     ``IsLower = Predicate(str.islower)``, ``IsUpper = Predicate(str.isupper)``, and
-    ``IsDigit = Predicate(str.isdigit)``. Users are encouraged to use methods which
+    ``IsDigits = Predicate(str.isdigit)``. Users are encouraged to use methods which
     can be given special handling, and avoid indirection like ``lambda s: s.lower()``.
 
     Some libraries might have special logic to handle certain predicates, e.g. by

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -354,7 +354,8 @@ Return True if the string is an uppercase string, False otherwise.
 
 A string is uppercase if all cased characters in the string are uppercase and there is at least one cased character in the string.
 """  # noqa: E501
-IsDigits = Annotated[_StrType, Predicate(str.isdigit)]
+IsDigit = Annotated[_StrType, Predicate(str.isdigit)]
+IsDigits = IsDigit  # type: ignore  # plural for backwards compatibility, see #63
 """
 Return True if the string is a digit string, False otherwise.
 

--- a/annotated_types/test_cases.py
+++ b/annotated_types/test_cases.py
@@ -121,7 +121,7 @@ def cases() -> Iterable[Case]:
 
     yield Case(at.LowerCase[str], ['abc', 'foobar'], ['', 'A', 'Boom'])
     yield Case(at.UpperCase[str], ['ABC', 'DEFO'], ['', 'a', 'abc', 'AbC'])
-    yield Case(at.IsDigits[str], ['123'], ['', 'ab', 'a1b2'])
+    yield Case(at.IsDigit[str], ['123'], ['', 'ab', 'a1b2'])
     yield Case(at.IsAscii[str], ['123', 'foo bar'], ['£100', '😊', 'whatever 👀'])
 
     yield Case(Annotated[int, at.Predicate(lambda x: x % 2 == 0)], [0, 2, 4], [1, 3, 5])


### PR DESCRIPTION
There are few typos that mistakenly claim the annotation is called `IsDigit`, while it's actually `IsDigits`.