### PR TITLE
Add `Unit` type

### DIFF
--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -301,8 +301,8 @@ class Timezone(BaseMetadata):
 class Quantity(BaseMetadata):
     """Indicates that the value is a physical quantity with the specified unit.
 
-    It is intended for usage with numeric types,
-    where the value represents the magnitude of the quantity.
+    It is intended for usage with numeric types, where the value represents the
+    magnitude of the quantity.
 
     Interpretation of the unit string is left to the discretion of the consumer.
     """

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -301,7 +301,7 @@ class Timezone(BaseMetadata):
 class Quantity(BaseMetadata):
     """Indicates that the value is a physical quantity with the specified unit.
 
-    It is intended for usage with numeric types (any instance of ``numbers.Number``),
+    It is intended for usage with numeric types,
     where the value represents the magnitude of the quantity.
 
     Interpretation of the unit string is left to the discretion of the consumer.

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -3,7 +3,17 @@ import sys
 import types
 from dataclasses import dataclass
 from datetime import tzinfo
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, SupportsFloat, SupportsIndex, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterator,
+    Optional,
+    SupportsFloat,
+    SupportsIndex,
+    TypeVar,
+    Union,
+)
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol, runtime_checkable
@@ -27,38 +37,38 @@ else:
 
 
 __all__ = (
-    'BaseMetadata',
-    'GroupedMetadata',
-    'Gt',
-    'Ge',
-    'Lt',
-    'Le',
-    'Interval',
-    'MultipleOf',
-    'MinLen',
-    'MaxLen',
-    'Len',
-    'Timezone',
-    'Unit',
-    'Predicate',
-    'LowerCase',
-    'UpperCase',
-    'IsDigits',
-    'IsFinite',
-    'IsNotFinite',
-    'IsNan',
-    'IsNotNan',
-    'IsInfinite',
-    'IsNotInfinite',
-    'doc',
-    'DocInfo',
-    '__version__',
+    "BaseMetadata",
+    "GroupedMetadata",
+    "Gt",
+    "Ge",
+    "Lt",
+    "Le",
+    "Interval",
+    "MultipleOf",
+    "MinLen",
+    "MaxLen",
+    "Len",
+    "Timezone",
+    "Unit",
+    "Predicate",
+    "LowerCase",
+    "UpperCase",
+    "IsDigits",
+    "IsFinite",
+    "IsNotFinite",
+    "IsNan",
+    "IsNotNan",
+    "IsInfinite",
+    "IsNotInfinite",
+    "doc",
+    "DocInfo",
+    "__version__",
 )
 
-__version__ = '0.6.0'
+__version__ = "0.6.0"
 
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 # arguments that start with __ are considered
@@ -67,33 +77,27 @@ T = TypeVar('T')
 
 
 class SupportsGt(Protocol):
-    def __gt__(self: T, __other: T) -> bool:
-        ...
+    def __gt__(self: T, __other: T) -> bool: ...
 
 
 class SupportsGe(Protocol):
-    def __ge__(self: T, __other: T) -> bool:
-        ...
+    def __ge__(self: T, __other: T) -> bool: ...
 
 
 class SupportsLt(Protocol):
-    def __lt__(self: T, __other: T) -> bool:
-        ...
+    def __lt__(self: T, __other: T) -> bool: ...
 
 
 class SupportsLe(Protocol):
-    def __le__(self: T, __other: T) -> bool:
-        ...
+    def __le__(self: T, __other: T) -> bool: ...
 
 
 class SupportsMod(Protocol):
-    def __mod__(self: T, __other: T) -> T:
-        ...
+    def __mod__(self: T, __other: T) -> T: ...
 
 
 class SupportsDiv(Protocol):
-    def __div__(self: T, __other: T) -> T:
-        ...
+    def __div__(self: T, __other: T) -> T: ...
 
 
 class BaseMetadata:
@@ -186,8 +190,7 @@ class GroupedMetadata(Protocol):
     def __is_annotated_types_grouped_metadata__(self) -> Literal[True]:
         return True
 
-    def __iter__(self) -> Iterator[BaseMetadata]:
-        ...
+    def __iter__(self) -> Iterator[BaseMetadata]: ...
 
     if not TYPE_CHECKING:
         __slots__ = ()  # allow subclasses to use slots
@@ -196,7 +199,9 @@ class GroupedMetadata(Protocol):
             # Basic ABC like functionality without the complexity of an ABC
             super().__init_subclass__(*args, **kwargs)
             if cls.__iter__ is GroupedMetadata.__iter__:
-                raise TypeError("Can't subclass GroupedMetadata without implementing __iter__")
+                raise TypeError(
+                    "Can't subclass GroupedMetadata without implementing __iter__"
+                )
 
         def __iter__(self) -> Iterator[BaseMetadata]:  # noqa: F811
             raise NotImplementedError  # more helpful than "None has no attribute..." type errors
@@ -302,9 +307,19 @@ class Unit(BaseMetadata):
     """Indicates that the value is a physical quantity with the specified unit.
 
     It is intended for usage with numeric types, where the value represents the
-    magnitude of the quantity.
+    magnitude of the quantity. For example, ``distance: Annotated[float, Unit('m')]``
+    or ``speed: Annotated[float, Unit('m/s')]``.
 
     Interpretation of the unit string is left to the discretion of the consumer.
+    It is suggested to follow conventions established by python libraries that work
+    with physical quantities, such as
+
+    - ``pint`` : <https://pint.readthedocs.io/en/stable/>
+    - ``astropy.units``: <https://docs.astropy.org/en/stable/units/>
+
+    For indicating a quantity with a certain dimensionality but without a specific unit
+    it is recommended to use square brackets, e.g. `Annotated[float, Unit('[time]')]`.
+    Note, however, ``annotated_types`` itself makes no use of the unit string.
     """
 
     unit: str
@@ -382,7 +397,7 @@ Return True if all characters in the string are ASCII, False otherwise.
 ASCII characters have code points in the range U+0000-U+007F. Empty string is ASCII too.
 """
 
-_NumericType = TypeVar('_NumericType', bound=Union[SupportsFloat, SupportsIndex])
+_NumericType = TypeVar("_NumericType", bound=Union[SupportsFloat, SupportsIndex])
 IsFinite = Annotated[_NumericType, Predicate(math.isfinite)]
 """Return True if x is neither an infinity nor a NaN, and False otherwise."""
 IsNotFinite = Annotated[_NumericType, Predicate(Not(math.isfinite))]

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -39,7 +39,7 @@ __all__ = (
     'MaxLen',
     'Len',
     'Timezone',
-    'Quantity',
+    'Unit',
     'Predicate',
     'LowerCase',
     'UpperCase',
@@ -298,7 +298,7 @@ class Timezone(BaseMetadata):
 
 
 @dataclass(frozen=True, **SLOTS)
-class Quantity(BaseMetadata):
+class Unit(BaseMetadata):
     """Indicates that the value is a physical quantity with the specified unit.
 
     It is intended for usage with numeric types, where the value represents the

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -39,6 +39,7 @@ __all__ = (
     'MaxLen',
     'Len',
     'Timezone',
+    'Quantity',
     'Predicate',
     'LowerCase',
     'UpperCase',
@@ -294,6 +295,19 @@ class Timezone(BaseMetadata):
     """
 
     tz: Union[str, tzinfo, EllipsisType, None]
+
+
+@dataclass(frozen=True, **SLOTS)
+class Quantity(BaseMetadata):
+    """Indicates that the value is a physical quantity with the specified unit.
+
+    It is intended for usage with numeric types (any instance of ``numbers.Number``),
+    where the value represents the magnitude of the quantity.
+
+    Interpretation of the unit string is left to the discretion of the consumer.
+    """
+
+    unit: str
 
 
 @dataclass(frozen=True, **SLOTS)

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -295,6 +295,7 @@ class Timezone(BaseMetadata):
 
     tz: Union[str, tzinfo, EllipsisType, None]
 
+
 @dataclass(frozen=True, **SLOTS)
 class Unit(BaseMetadata):
     """Indicates that the value is a physical quantity with the specified unit.

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -3,17 +3,7 @@ import sys
 import types
 from dataclasses import dataclass
 from datetime import tzinfo
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Iterator,
-    Optional,
-    SupportsFloat,
-    SupportsIndex,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, SupportsFloat, SupportsIndex, TypeVar, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol, runtime_checkable
@@ -37,38 +27,37 @@ else:
 
 
 __all__ = (
-    "BaseMetadata",
-    "GroupedMetadata",
-    "Gt",
-    "Ge",
-    "Lt",
-    "Le",
-    "Interval",
-    "MultipleOf",
-    "MinLen",
-    "MaxLen",
-    "Len",
-    "Timezone",
-    "Unit",
-    "Predicate",
-    "LowerCase",
-    "UpperCase",
-    "IsDigits",
-    "IsFinite",
-    "IsNotFinite",
-    "IsNan",
-    "IsNotNan",
-    "IsInfinite",
-    "IsNotInfinite",
-    "doc",
-    "DocInfo",
-    "__version__",
+    'BaseMetadata',
+    'GroupedMetadata',
+    'Gt',
+    'Ge',
+    'Lt',
+    'Le',
+    'Interval',
+    'MultipleOf',
+    'MinLen',
+    'MaxLen',
+    'Len',
+    'Timezone',
+    'Predicate',
+    'LowerCase',
+    'UpperCase',
+    'IsDigits',
+    'IsFinite',
+    'IsNotFinite',
+    'IsNan',
+    'IsNotNan',
+    'IsInfinite',
+    'IsNotInfinite',
+    'doc',
+    'DocInfo',
+    '__version__',
 )
 
-__version__ = "0.6.0"
+__version__ = '0.6.0'
 
 
-T = TypeVar("T")
+T = TypeVar('T')
 
 
 # arguments that start with __ are considered
@@ -77,27 +66,33 @@ T = TypeVar("T")
 
 
 class SupportsGt(Protocol):
-    def __gt__(self: T, __other: T) -> bool: ...
+    def __gt__(self: T, __other: T) -> bool:
+        ...
 
 
 class SupportsGe(Protocol):
-    def __ge__(self: T, __other: T) -> bool: ...
+    def __ge__(self: T, __other: T) -> bool:
+        ...
 
 
 class SupportsLt(Protocol):
-    def __lt__(self: T, __other: T) -> bool: ...
+    def __lt__(self: T, __other: T) -> bool:
+        ...
 
 
 class SupportsLe(Protocol):
-    def __le__(self: T, __other: T) -> bool: ...
+    def __le__(self: T, __other: T) -> bool:
+        ...
 
 
 class SupportsMod(Protocol):
-    def __mod__(self: T, __other: T) -> T: ...
+    def __mod__(self: T, __other: T) -> T:
+        ...
 
 
 class SupportsDiv(Protocol):
-    def __div__(self: T, __other: T) -> T: ...
+    def __div__(self: T, __other: T) -> T:
+        ...
 
 
 class BaseMetadata:
@@ -190,7 +185,8 @@ class GroupedMetadata(Protocol):
     def __is_annotated_types_grouped_metadata__(self) -> Literal[True]:
         return True
 
-    def __iter__(self) -> Iterator[BaseMetadata]: ...
+    def __iter__(self) -> Iterator[BaseMetadata]:
+        ...
 
     if not TYPE_CHECKING:
         __slots__ = ()  # allow subclasses to use slots
@@ -199,9 +195,7 @@ class GroupedMetadata(Protocol):
             # Basic ABC like functionality without the complexity of an ABC
             super().__init_subclass__(*args, **kwargs)
             if cls.__iter__ is GroupedMetadata.__iter__:
-                raise TypeError(
-                    "Can't subclass GroupedMetadata without implementing __iter__"
-                )
+                raise TypeError("Can't subclass GroupedMetadata without implementing __iter__")
 
         def __iter__(self) -> Iterator[BaseMetadata]:  # noqa: F811
             raise NotImplementedError  # more helpful than "None has no attribute..." type errors
@@ -301,7 +295,6 @@ class Timezone(BaseMetadata):
 
     tz: Union[str, tzinfo, EllipsisType, None]
 
-
 @dataclass(frozen=True, **SLOTS)
 class Unit(BaseMetadata):
     """Indicates that the value is a physical quantity with the specified unit.
@@ -397,7 +390,7 @@ Return True if all characters in the string are ASCII, False otherwise.
 ASCII characters have code points in the range U+0000-U+007F. Empty string is ASCII too.
 """
 
-_NumericType = TypeVar("_NumericType", bound=Union[SupportsFloat, SupportsIndex])
+_NumericType = TypeVar('_NumericType', bound=Union[SupportsFloat, SupportsIndex])
 IsFinite = Annotated[_NumericType, Predicate(math.isfinite)]
 """Return True if x is neither an infinity nor a NaN, and False otherwise."""
 IsNotFinite = Annotated[_NumericType, Predicate(Not(math.isfinite))]

--- a/annotated_types/test_cases.py
+++ b/annotated_types/test_cases.py
@@ -117,6 +117,10 @@ def cases() -> Iterable[Case]:
         [datetime(2000, 1, 1), datetime(2000, 1, 1, tzinfo=timezone(timedelta(hours=6)))],
     )
 
+    # Quantity
+
+    yield Case(Annotated[float, at.Quantity(unit='m')], (5, 4.2), ('5m', '4.2m'))
+
     # predicate types
 
     yield Case(at.LowerCase[str], ['abc', 'foobar'], ['', 'A', 'Boom'])
@@ -145,3 +149,4 @@ def cases() -> Iterable[Case]:
             yield at.Predicate(lambda x: float(x).is_integer())
 
     yield Case(Annotated[float, MyCustomGroupedMetadata()], [0, 2.0], [0.01, 1.5])
+

--- a/annotated_types/test_cases.py
+++ b/annotated_types/test_cases.py
@@ -119,7 +119,7 @@ def cases() -> Iterable[Case]:
 
     # Quantity
 
-    yield Case(Annotated[float, at.Quantity(unit='m')], (5, 4.2), ('5m', '4.2m'))
+    yield Case(Annotated[float, at.Unit(unit='m')], (5, 4.2), ('5m', '4.2m'))
 
     # predicate types
 

--- a/annotated_types/test_cases.py
+++ b/annotated_types/test_cases.py
@@ -149,4 +149,3 @@ def cases() -> Iterable[Case]:
             yield at.Predicate(lambda x: float(x).is_integer())
 
     yield Case(Annotated[float, MyCustomGroupedMetadata()], [0, 2.0], [0.01, 1.5])
-

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 import math
-import sys
 import numbers
+import sys
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Iterator, Type, Union
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -77,9 +77,11 @@ def check_timezone(constraint: Constraint, val: Any) -> bool:
     # ellipsis
     return val.tzinfo is not None
 
+
 def check_quantity(constraint: Constraint, val: Any) -> bool:
     assert isinstance(constraint, annotated_types.Quantity)
     return isinstance(val, numbers.Number)
+
 
 Validator = Callable[[Constraint, Any], bool]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -79,7 +79,7 @@ def check_timezone(constraint: Constraint, val: Any) -> bool:
 
 def check_quantity(constraint: Constraint, val: Any) -> bool:
     assert isinstance(constraint, annotated_types.Quantity)
-    return isinstance(val, float)
+    return isinstance(val, (float, int))
 
 
 Validator = Callable[[Constraint, Any], bool]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,4 @@
 import math
-import numbers
 import sys
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Iterator, Type, Union
@@ -80,7 +79,7 @@ def check_timezone(constraint: Constraint, val: Any) -> bool:
 
 def check_quantity(constraint: Constraint, val: Any) -> bool:
     assert isinstance(constraint, annotated_types.Quantity)
-    return isinstance(val, numbers.Number)
+    return isinstance(val, float)
 
 
 Validator = Callable[[Constraint, Any], bool]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -78,7 +78,7 @@ def check_timezone(constraint: Constraint, val: Any) -> bool:
 
 
 def check_quantity(constraint: Constraint, val: Any) -> bool:
-    assert isinstance(constraint, annotated_types.Quantity)
+    assert isinstance(constraint, annotated_types.Unit)
     return isinstance(val, (float, int))
 
 
@@ -95,7 +95,7 @@ VALIDATORS: Dict[Type[Constraint], Validator] = {
     annotated_types.MinLen: check_min_len,
     annotated_types.MaxLen: check_max_len,
     annotated_types.Timezone: check_timezone,
-    annotated_types.Quantity: check_quantity,
+    annotated_types.Unit: check_quantity,
 }
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 import math
 import sys
+import numbers
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Iterator, Type, Union
 
@@ -76,6 +77,9 @@ def check_timezone(constraint: Constraint, val: Any) -> bool:
     # ellipsis
     return val.tzinfo is not None
 
+def check_quantity(constraint: Constraint, val: Any) -> bool:
+    assert isinstance(constraint, annotated_types.Quantity)
+    return isinstance(val, numbers.Number)
 
 Validator = Callable[[Constraint, Any], bool]
 
@@ -90,6 +94,7 @@ VALIDATORS: Dict[Type[Constraint], Validator] = {
     annotated_types.MinLen: check_min_len,
     annotated_types.MaxLen: check_max_len,
     annotated_types.Timezone: check_timezone,
+    annotated_types.Quantity: check_quantity,
 }
 
 


### PR DESCRIPTION
Adds a `Unit` type (for discussion, see #64). 

examples:
```python
width: Annotated[float, Unit('m')] = 1
angle: Annotated[float, Unit('rad') = 0
temperature: Annotated[float, Unit('celsius')] = 100
weight: Annotated[float, Unit('kg') = 42
``` 

*annotated_types makes no attempt to parse the unit string*