### PR TITLE
Make Not a BaseMetadata so that it can wrap arbitrary other metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,11 @@ For some common constraints, we provide generic types:
 * `IsUpper       = Annotated[T, Predicate(str.isupper)]`
 * `IsDigit       = Annotated[T, Predicate(str.isdigit)]`
 * `IsFinite      = Annotated[T, Predicate(math.isfinite)]`
-* `IsNotFinite   = Annotated[T, Predicate(Not(math.isfinite))]`
+* `IsNotFinite   = Annotated[T, Not(Predicate(math.isfinite))]`
 * `IsNan         = Annotated[T, Predicate(math.isnan)]`
-* `IsNotNan      = Annotated[T, Predicate(Not(math.isnan))]`
+* `IsNotNan      = Annotated[T, Not(Predicate(math.isnan))]`
 * `IsInfinite    = Annotated[T, Predicate(math.isinf)]`
-* `IsNotInfinite = Annotated[T, Predicate(Not(math.isinf))]`
+* `IsNotInfinite = Annotated[T, Not(Predicate(math.isinf))]`
 
 so that you can write e.g. `x: IsFinite[float] = 2.0` instead of the longer
 (but exactly equivalent) `x: Annotated[float, Predicate(math.isfinite)] = 2.0`.
@@ -213,6 +213,11 @@ It expects a value that can be statically analyzed, as the main use case is for 
 It returns a `DocInfo` class with a single attribute `documentation` containing the value passed to `doc()`.
 
 This is the early adopter's alternative form of the [`typing-doc` proposal](https://github.com/tiangolo/fastapi/blob/typing-doc/typing_doc.md).
+
+### Not
+
+Not negates any predicate or metadata object. It is used to express that a value should not satisfy a predicate or metadata object.
+This may not make sense for all metadata objects, implementers should decide how to handle these cases.
 
 ### Integrating downstream types with `GroupedMetadata`
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ This is the early adopter's alternative form of the [`typing-doc` proposal](http
 
 ### Not
 
-Not negates any predicate or metadata object. It is used to express that a value should not satisfy a predicate or metadata object.
+Not negates any predicate or metadata object.
+It is used to express that a value should not satisfy a predicate or metadata object.
+For example, `Annotated[int, Not(Gt(10))]` would be an integer that is less than or equal to 10.
 This may not make sense for all metadata objects, implementers should decide how to handle these cases.
 
 ### Integrating downstream types with `GroupedMetadata`

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -356,11 +356,8 @@ class Predicate(BaseMetadata):
 
 
 @dataclass
-class Not:
-    func: Callable[[Any], bool]
-
-    def __call__(self, __v: Any) -> bool:
-        return not self.func(__v)
+class Not(BaseMetadata):
+    inner: BaseMetadata
 
 
 _StrType = TypeVar("_StrType", bound=str)
@@ -394,15 +391,15 @@ ASCII characters have code points in the range U+0000-U+007F. Empty string is AS
 _NumericType = TypeVar('_NumericType', bound=Union[SupportsFloat, SupportsIndex])
 IsFinite = Annotated[_NumericType, Predicate(math.isfinite)]
 """Return True if x is neither an infinity nor a NaN, and False otherwise."""
-IsNotFinite = Annotated[_NumericType, Predicate(Not(math.isfinite))]
+IsNotFinite = Annotated[_NumericType, Not(Predicate(math.isfinite))]
 """Return True if x is one of infinity or NaN, and False otherwise"""
 IsNan = Annotated[_NumericType, Predicate(math.isnan)]
 """Return True if x is a NaN (not a number), and False otherwise."""
-IsNotNan = Annotated[_NumericType, Predicate(Not(math.isnan))]
+IsNotNan = Annotated[_NumericType, Not(Predicate(math.isnan))]
 """Return True if x is anything but NaN (not a number), and False otherwise."""
 IsInfinite = Annotated[_NumericType, Predicate(math.isinf)]
 """Return True if x is a positive or negative infinity, and False otherwise."""
-IsNotInfinite = Annotated[_NumericType, Predicate(Not(math.isinf))]
+IsNotInfinite = Annotated[_NumericType, Not(Predicate(math.isinf))]
 """Return True if x is neither a positive or negative infinity, and False otherwise."""
 
 try:

--- a/annotated_types/test_cases.py
+++ b/annotated_types/test_cases.py
@@ -149,3 +149,7 @@ def cases() -> Iterable[Case]:
             yield at.Predicate(lambda x: float(x).is_integer())
 
     yield Case(Annotated[float, MyCustomGroupedMetadata()], [0, 2.0], [0.01, 1.5])
+
+    # negation
+    yield Case(Annotated[int, at.Not(at.Gt(0))], (-1, 0), (1,))
+    yield Case(Annotated[int, at.Not(at.Predicate(math.isfinite))], (math.nan, math.inf), (1, 0))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -82,6 +82,12 @@ def check_quantity(constraint: Constraint, val: Any) -> bool:
     return isinstance(val, (float, int))
 
 
+def check_negation(constraint: Constraint, val: Any) -> bool:
+    assert isinstance(constraint, annotated_types.Not)
+    inner = VALIDATORS[type(constraint.inner)]
+    return not inner(constraint.inner, val)
+
+
 Validator = Callable[[Constraint, Any], bool]
 
 
@@ -96,6 +102,7 @@ VALIDATORS: Dict[Type[Constraint], Validator] = {
     annotated_types.MaxLen: check_max_len,
     annotated_types.Timezone: check_timezone,
     annotated_types.Unit: check_quantity,
+    annotated_types.Not: check_negation,
 }
 
 


### PR DESCRIPTION
The idea is that you can write `Not(Gt(0))` and have that be interpretable by implementers.