### PR TITLE
Rename DocInfo to Doc

### DIFF
--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -422,16 +422,4 @@ except ImportError:
 
 
 DocInfo = Doc  # backwards compatibility
-
-
-def doc(
-    documentation: str,
-) -> Doc:
-    """
-    Add documentation to a type annotation inside of Annotated.
-
-    For example:
-
-    >>> def hi(name: Annotated[int, doc("The name of the user")]) -> None: ...
-    """
-    return Doc(documentation)
+doc = Doc

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -407,7 +407,7 @@ IsNotInfinite = Annotated[_NumericType, Predicate(Not(math.isinf))]
 
 try:
     # PEP 727 – Documentation in Annotated Metadata
-    from typing_extensions import Doc # type: ignore [no-redef]
+    from typing_extensions import Doc  # type: ignore[attr-defined]
 except ImportError:
 
     @dataclass(frozen=True, **SLOTS)
@@ -420,7 +420,9 @@ except ImportError:
         documentation: str
         """The documentation string passed to doc()."""
 
-DocInfo = Doc # backwards compatibility
+
+DocInfo = Doc  # backwards compatibility
+
 
 def doc(
     documentation: str,

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -406,11 +406,12 @@ IsNotInfinite = Annotated[_NumericType, Predicate(Not(math.isinf))]
 """Return True if x is neither a positive or negative infinity, and False otherwise."""
 
 try:
-    from typing_extensions import DocInfo, doc  # type: ignore [attr-defined]
+    # PEP 727 – Documentation in Annotated Metadata
+    from typing_extensions import Doc # type: ignore [no-redef]
 except ImportError:
 
     @dataclass(frozen=True, **SLOTS)
-    class DocInfo:  # type: ignore [no-redef]
+    class Doc:  # type: ignore [no-redef]
         """ "
         The return value of doc(), mainly to be used by tools that want to extract the
         Annotated documentation at runtime.
@@ -419,14 +420,16 @@ except ImportError:
         documentation: str
         """The documentation string passed to doc()."""
 
-    def doc(
-        documentation: str,
-    ) -> DocInfo:
-        """
-        Add documentation to a type annotation inside of Annotated.
+DocInfo = Doc # backwards compatibility
 
-        For example:
+def doc(
+    documentation: str,
+) -> Doc:
+    """
+    Add documentation to a type annotation inside of Annotated.
 
-        >>> def hi(name: Annotated[int, doc("The name of the user")]) -> None: ...
-        """
-        return DocInfo(documentation)
+    For example:
+
+    >>> def hi(name: Annotated[int, doc("The name of the user")]) -> None: ...
+    """
+    return Doc(documentation)


### PR DESCRIPTION
[pep-727](https://peps.python.org/pep-0727/) provide documentation strings for Python symbols defined with Annotated using class `typing.Doc` rather than `typing.DocInfo`

https://github.com/python/typing_extensions/pull/277
