### PR TITLE
Update license-files to be PEP-639 compliant (#85)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 readme = "README.md"
 repository = "https://github.com/annotated-types/annotated-types"
-license-files = { paths = ['LICENSE'] }
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Hatchling 1.26.0 introduced a check [0] for the project.license-files key to be PEP-639 [1] compliant.
On the same day, hatchling added a backwards compatible workaround in 1.26.1. While this works for now, chances are other tools will not be as forgiving in the future, so it still makes sense to update the field.

[0]: https://github.com/pypa/hatch/commit/28f233c535508247ffa9a40dab82c1d1cb2b700b#diff-b29708f9e31a5480d8552a96951ee054262d2d12b906e3997413eacc99f33b90R751-R753
[1]: https://peps.python.org/pep-0639/

Closes #85.