### PR TITLE
add CI for PyPy3.11 and fix test (issue 71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy3.11', '3.12', '3.13']
 
     runs-on: ubuntu-latest
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -151,12 +151,12 @@ def a_predicate_fn(x: object) -> bool:
 @pytest.mark.parametrize(
     "pred, repr_",
     [
-        (annotated_types.Predicate(func=a_predicate_fn), "Predicate(a_predicate_fn)"),
-        (annotated_types.Predicate(func=str.isascii), "Predicate(str.isascii)"),
-        (annotated_types.Predicate(func=math.isfinite), "Predicate(math.isfinite)"),
-        (annotated_types.Predicate(func=bool), "Predicate(bool)"),
-        (annotated_types.Predicate(func := lambda _: True), f"Predicate({func!r})"),
+        (annotated_types.Predicate(func=a_predicate_fn), ["Predicate(a_predicate_fn)"]),
+        (annotated_types.Predicate(func=str.isascii), ["Predicate(str.isascii)"]),
+        (annotated_types.Predicate(func=math.isfinite), ["Predicate(math.isfinite)", "Predicate(isfinite)"]),
+        (annotated_types.Predicate(func=bool), ["Predicate(bool)"]),
+        (annotated_types.Predicate(func := lambda _: True), [f"Predicate({func!r})"]),
     ],
 )
 def test_predicate_repr(pred: annotated_types.Predicate, repr_: str) -> None:
-    assert repr(pred) == repr_
+    assert repr(pred) in repr_


### PR DESCRIPTION
Fixes #71 and adds CI for PyPy3.11. There might be a better fix by finding a builtin that has the same repr on CPython and PyPy, but it seems the sentiment in the issue was to accept the reality we have.

cc @Zac-HD 