### PR TITLE
Fix string predicate names in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ the full power and flexibility of arbitrary runtime predicates... here it is.
 
 For some common constraints, we provide generic types:
 
-* `IsLower       = Annotated[T, Predicate(str.islower)]`
-* `IsUpper       = Annotated[T, Predicate(str.isupper)]`
+* `LowerCase     = Annotated[T, Predicate(str.islower)]`
+* `UpperCase     = Annotated[T, Predicate(str.isupper)]`
 * `IsDigit       = Annotated[T, Predicate(str.isdigit)]`
 * `IsFinite      = Annotated[T, Predicate(math.isfinite)]`
 * `IsNotFinite   = Annotated[T, Predicate(Not(math.isfinite))]`

--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -327,7 +327,7 @@ class Predicate(BaseMetadata):
     power and flexibility of arbitrary runtime predicates... here it is.
 
     We provide a few predefined predicates for common string constraints:
-    ``IsLower = Predicate(str.islower)``, ``IsUpper = Predicate(str.isupper)``, and
+    ``LowerCase = Predicate(str.islower)``, ``UpperCase = Predicate(str.isupper)``, and
     ``IsDigits = Predicate(str.isdigit)``. Users are encouraged to use methods which
     can be given special handling, and avoid indirection like ``lambda s: s.lower()``.
 


### PR DESCRIPTION
The predicate names are LowerCase, UpperCase instead of IsLower, IsUpper

Closes #89 