### PR TITLE
Prepare for 0.8.0 release

### DIFF
--- a/annotated_types/__init__.py
+++ b/annotated_types/__init__.py
@@ -45,7 +45,7 @@ __all__ = (
     '__version__',
 )
 
-__version__ = '0.7.0'
+__version__ = '0.8.0'
 
 
 T = TypeVar('T')


### PR DESCRIPTION
Bumps `__version__` to `0.8.0` in preparation for a new PyPI release, addressing #102 (last release 0.7.0 was over two years ago).

## Changes included since v0.7.0
- Add support for Python 3.13 and 3.14 (#83, #96, #97)
- Drop EOL Python 3.8 and 3.9 (#97)
- Rename `DocInfo` → `Doc` with a backwards-compatible alias (#80)
- Add CI for PyPy 3.11 (#88)
- Add SPDX license expression / PEP-639 compliant `license-files` (#85, #86, #92)
- README and docstring fixes (#84, #87, #90, #100)

## Release process
Merging this does **not** publish. Publishing to PyPI is triggered by pushing a `v0.8.0` tag (see below) — the CI `deploy` job verifies the tag matches `annotated_types/__init__.py` and uploads to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)