### PR TITLE
Switch PyPI release to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: set up python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
-
-      - run: pip install -U twine build
+      - name: install uv
+        uses: astral-sh/setup-uv@v6
 
       - name: check GITHUB_REF matches package version
         uses: samuelcolvin/check-python-version@v5
@@ -87,9 +83,9 @@ jobs:
           version_file_path: annotated_types/__init__.py
 
       - name: build
-        run: python -m build
+        run: uv build
 
-      - run: twine check dist/*
-
+      # uv detects the ambient OIDC credentials (id-token: write + the
+      # annotated-types environment) and mints the trusted-publishing token itself.
       - name: upload to pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
+        run: uv publish --trusted-publishing always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
       - lint
     if: "success() && startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
+    environment: annotated-types
+    permissions:
+      # required for trusted publishing to PyPI (OIDC)
+      id-token: write
 
     steps:
       - uses: actions/checkout@v5
@@ -88,7 +92,4 @@ jobs:
       - run: twine check dist/*
 
       - name: upload to pypi
-        run: twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.pypi_token }}
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## What

Cuts the release job over from a token-based `twine upload` to **PyPI trusted publishing** (OIDC), matching the trusted publisher already configured on PyPI (repo `annotated-types/annotated-types`, workflow `ci.yml`, environment `annotated-types`).

## Changes to the `deploy` job

- `environment: annotated-types` — **required** so the OIDC token carries the environment claim PyPI expects. This environment is also gated with required reviewers (adriangb / samuelcolvin / Zac-HD) and restricted to tag refs.
- `permissions: id-token: write` — required to mint the OIDC token. Everything else stays at the repo default (read).
- Replaced `twine upload` (+ `secrets.pypi_token`) with `uv build` + `uv publish --trusted-publishing always` (per @samuelcolvin's preference for uv). uv detects the ambient OIDC credentials and mints the token itself — no explicit token needed.

## After merge

1. Push a release tag from a commit **that includes this change** (the workflow that runs on a tag is the one at that tag's commit).
2. Approve the deployment when the `annotated-types` environment prompts.
3. Confirm it publishes to PyPI.
4. **Then** delete the now-unused `PYPI_TOKEN` repo secret and **revoke** the token on PyPI (deleting the secret does not invalidate the token).

Note: this PR's CI does not exercise the publish step (it's gated to tag refs), only test/lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)